### PR TITLE
Reset `listWindow` only after cleaning all windows instances

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -107,8 +107,8 @@ const createMainWindow = async () => {
     listWindow.forEach(instance => {
       instance.serverProcess.kill();
       (instance.window.webContents as any)?.destroy() // TODO: electron haven't make document for it. Ref: https://github.com/electron/electron/issues/26929
-      listWindow = [];
     });
+    listWindow = [];
   })
 
   if (isDev) {


### PR DESCRIPTION
Not sure it's an actual issue but while reading the code I was thinking that that'd make more sense. WDYT? 🤔